### PR TITLE
Add Stable Diffusion Diffuser environment to custom-environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You can create the environment by copying the `.yml` file and right click copied
 * [fast.ai](custom-environments/fastai/fastai.yml)
 * [Geospatial environment](custom-environments/Geospatial/geospatial.yml)
 * [SciPy](custom-environments/SciPy/scipy.yml)
+* [Diffusers](custom-environments/diffusers/diffusers.yml)
 
 ### Community contents
 

--- a/custom-environments/diffusers/README.md
+++ b/custom-environments/diffusers/README.md
@@ -1,0 +1,8 @@
+# `diffusers` Custom Environment
+
+This folder contains a example yml file to create a custom SageMaker Studio Lab environment for `diffusers` to run Stable Diffusion.
+
+Building this environment and running Stable Diffusion v2 requires significant space. Be sure to remove unnecessary files and caches. (ex. running `df -h` and `du -sh` to check disk and folder size, running `conda clean --all` and `pip cache purge` to clean conda and pip cache)
+
+- Conda Environment: ~10GB for installation, ~7GB after removing cache
+- Stable Diffusion v2: ~3GB (for 768x768)

--- a/custom-environments/diffusers/diffusers.ipynb
+++ b/custom-environments/diffusers/diffusers.ipynb
@@ -24,7 +24,8 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "from diffusers import StableDiffusionPipeline"
+    "from diffusers import StableDiffusionPipeline\n",
+    "import IPython.display as display"
    ]
   },
   {
@@ -59,13 +60,14 @@
    "source": [
     "prompt = \"a photo of an astronaut riding a horse on mars\"\n",
     "image = pipe(prompt, height=768, width=768).images[0]\n",
-    "image.save(\"test.png\")"
+    "image.save(\"test.png\")\n",
+    "display.display(image)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a524927b-6819-412c-9ee5-fffce5533b1a",
+   "id": "ab600abf-0314-4e93-bb95-b8008d2b6aa0",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/custom-environments/diffusers/diffusers.ipynb
+++ b/custom-environments/diffusers/diffusers.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "18009882-afb5-4ca1-ae6c-455404b3e2f6",
+   "metadata": {},
+   "source": [
+    "# Stable Diffusion with diffusers\n",
+    "\n",
+    "[![Open In Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/aws/studio-lab-examples/blob/main/custom-environments/diffusers.ipynb)\n",
+    "\n",
+    "This is sample notebook of running [Stable Diffusion v2](https://huggingface.co/stabilityai/stable-diffusion-2) with [diffusers](https://github.com/huggingface/diffusers) on SageMaker Studio Lab.\n",
+    "\n",
+    "This notebook is designed to work in both CPU and GPU environment.\n",
+    "\n",
+    "It is recommended to run this notebook on GPU runtime since it is very slow on CPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f3cc787-1f30-45bd-9094-d7f62ce07f9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from diffusers import StableDiffusionPipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fbdbddf-fd30-4a38-af67-246afc6773a1",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model_name = \"stabilityai/stable-diffusion-2\"\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "print(device)\n",
+    "\n",
+    "if device == \"cuda\":\n",
+    "    pipe = StableDiffusionPipeline.from_pretrained(\n",
+    "        model_name, torch_dtype=torch.float16, revision=\"fp16\"\n",
+    "    )\n",
+    "else:\n",
+    "    pipe = StableDiffusionPipeline.from_pretrained(model_name)\n",
+    "pipe = pipe.to(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d68c0769-44a4-4bd2-9748-93285564923b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = \"a photo of an astronaut riding a horse on mars\"\n",
+    "image = pipe(prompt, height=768, width=768).images[0]\n",
+    "image.save(\"test.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a524927b-6819-412c-9ee5-fffce5533b1a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "diffusers:Python",
+   "language": "python",
+   "name": "conda-env-diffusers-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/custom-environments/diffusers/diffusers.yml
+++ b/custom-environments/diffusers/diffusers.yml
@@ -1,0 +1,12 @@
+name: diffusers
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - ipython
+  - ipykernel
+  - diffusers
+  - transformers
+  - accelerate
+  - scipy
+  - ftfy


### PR DESCRIPTION
*Issue #, if available:*
#172 

*Description of changes:*
This Pull Request adds sample conda environment in yaml and notebook to run Stable Diffusion on `diffusers`.

*Testing done:*
- Tested Image Generation on GPU runtime of SageMaker Studio Lab by following procedures
  - Install dependencies using `conda env create -f diffusers.yml` in `custom-environments/diffusers`
  - Tested Image Generation with `stabilityai/stable-diffusion-2` with the environment on `custom-environments/diffusers/diffusers.ipynb`.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/studio-lab-examples/blob/main/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/studio-lab-examples/blob/main/README.md)
- [x] I have confirmed secret codes are not included in the example.
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
