### PR TITLE
fix: small typo in prompting-mistral7B.ipynb

### DIFF
--- a/large-language-models/prompting-mistral7B.ipynb
+++ b/large-language-models/prompting-mistral7B.ipynb
@@ -248,7 +248,7 @@
    "id": "9046f28b-a89f-41f5-9d54-89263a396039",
    "metadata": {},
    "source": [
-    "# Dyanamic prompting\n",
+    "# Dynamic prompting\n",
     "Now that we know how to submit instructions to Mistral LLM, let's try assembling prompts dynamically - part of the prompt can be fixed, and part can be provided on the fly. We achieve this by creating prompt template with variables. The value for each variable is supplied in a separate statement and that statement can be executed further down in the code. Basically, this is a way to de-couple static part of the prompt from variable one, making the entire prompt dynamic. "
    ]
   },


### PR DESCRIPTION
Fixing small typo in Jupyter Notebook

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/studio-lab-examples/blob/main/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/studio-lab-examples/blob/main/README.md)
- [x] I have confirmed secret codes are not included in the example.
- [x] I have tested my notebook(s) and ensured it runs end-to-end
- [x] I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
