### PR TITLE
Fix missing conda cli argument for installing French and Chinese language packs

### DIFF
--- a/custom-environments/localization/README.md
+++ b/custom-environments/localization/README.md
@@ -4,9 +4,9 @@ We can localize the user interface by using [jupyterlab-language-pack](https://a
 
 1. Open the Terminal and install the language pack. The followings are example.
    * German: `conda install -c conda-forge jupyterlab-language-pack-de-de`
-   * French: `conda install -c jupyterlab-language-pack-fr-fr`
+   * French: `conda install -c conda-forge jupyterlab-language-pack-fr-fr`
    * Japanese: `conda install -c conda-forge jupyterlab-language-pack-ja-jp`
-   * Chinese: `conda install -c jupyterlab-language-pack-zh-cn`
+   * Chinese: `conda install -c conda-forge jupyterlab-language-pack-zh-cn`
 2. Restart the Jupyter Lab
    * ![restart_jupyter_lab.png](restart_jupyter_lab.png)
 3. Setting the Language


### PR DESCRIPTION
*Description of changes:*
The README detailing how to install new languages inside Jupyter Lab gives example of Conda commands. 2 out of the 4 examples are missing the channel argument value, which is probably a copy-paste error. I've simply added the missing channel value. 

*Testing done:*
Yes the command lines are now working with the proper channel name added. 

## Merge Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/aws/studio-lab-examples/blob/main/CONTRIBUTING.md) doc and adhered to the example notebook best practices
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/studio-lab-examples/blob/main/README.md)
- [X] I have confirmed secret codes are not included in the example.
- ~I have tested my notebook(s) and ensured it runs end-to-end~
- ~I have linted my notebook(s) and code using `black-nb -l 100 {path}/{notebook-name}.ipynb`~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
